### PR TITLE
fix: add fallback Helm secret when ESO is disabled

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -86,6 +86,9 @@ jobs:
             --set image.repository=${{ secrets.ACR_LOGIN_SERVER }}/${{ env.IMAGE_NAME }} \
             --set image.tag=${{ needs.build-and-push.outputs.image-tag }} \
             --set image.pullPolicy=Always \
+            --set secrets.dbPassword=${{ secrets.DB_PASSWORD }} \
+            --set secrets.jwtSecret=${{ secrets.JWT_SECRET }} \
+            --set secrets.demoSigningKey=${{ secrets.DEMO_SIGNING_KEY }} \
             --namespace ${{ env.NAMESPACE }} \
             --create-namespace \
             --wait --timeout 120s

--- a/deploy/helm/pebblr/templates/secret.yaml
+++ b/deploy/helm/pebblr/templates/secret.yaml
@@ -1,0 +1,25 @@
+{{- if not .Values.externalSecrets.enabled -}}
+apiVersion: v1
+kind: Secret
+metadata:
+  name: {{ include "pebblr.secretName" . }}
+  namespace: {{ .Release.Namespace }}
+  labels:
+    {{- include "pebblr.labels" . | nindent 4 }}
+type: Opaque
+stringData:
+  {{- $dsn := printf "postgres://%s:%s@%s:%s/%s?sslmode=%s"
+    .Values.database.user
+    .Values.secrets.dbPassword
+    .Values.database.host
+    (toString .Values.database.port)
+    .Values.database.name
+    .Values.database.sslMode }}
+  db-dsn: {{ $dsn | quote }}
+  {{ .Values.secrets.dbUrlKey }}: {{ $dsn | quote }}
+  {{ .Values.secrets.dbPasswordKey }}: {{ .Values.secrets.dbPassword | quote }}
+  {{ .Values.secrets.jwtSecretKey }}: {{ .Values.secrets.jwtSecret | quote }}
+  {{- if .Values.secrets.demoSigningKeyKey }}
+  {{ .Values.secrets.demoSigningKeyKey }}: {{ .Values.secrets.demoSigningKey | default "" | quote }}
+  {{- end }}
+{{- end }}

--- a/deploy/helm/pebblr/values.yaml
+++ b/deploy/helm/pebblr/values.yaml
@@ -68,6 +68,11 @@ secrets:
   jwtSecretKey: jwt-secret
   # Only needed when auth.provider=demo
   demoSigningKeyKey: ""
+  # Inline secret values — used only when externalSecrets.enabled=false.
+  # When ESO is enabled these are ignored (secrets come from KeyVault).
+  dbPassword: ""
+  jwtSecret: ""
+  demoSigningKey: ""
 
 # Database connection (non-secret parts)
 database:


### PR DESCRIPTION
## Summary
- Add `secret.yaml` template that creates a K8s Secret from Helm values when `externalSecrets.enabled=false`
- Constructs the DSN from `database.*` values, includes both `db-dsn` and `db-url` keys (API server and migration job use different filenames)
- Deploy workflow passes `DB_PASSWORD`, `JWT_SECRET`, `DEMO_SIGNING_KEY` from GitHub secrets
- When ESO is enabled, the fallback secret is not rendered

Fixes the AKS deploy failure: `MountVolume.SetUp failed for volume "secrets": secret "pebblr-secrets" not found`

## Test plan
- [x] `helm lint` passes
- [x] `helm template` renders correct secret with ESO disabled
- [x] `helm template` skips secret with ESO enabled
- [x] GitHub secrets `DB_PASSWORD`, `JWT_SECRET`, `DEMO_SIGNING_KEY` created
- [ ] Verify AKS deploy succeeds after merge

🤖 Generated with [Claude Code](https://claude.com/claude-code)