### PR TITLE
chore: add Go test report to CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,8 +26,19 @@ jobs:
       - name: Install frontend dependencies
         run: cd web && bun install --frozen-lockfile
 
+      - name: Install gotestsum
+        run: go install gotest.tools/gotestsum@latest
+
       - name: Run Go tests with coverage
-        run: go test -coverprofile=coverage.out ./...
+        run: gotestsum --junitfile go-test-results.xml -- -coverprofile=coverage.out ./...
+
+      - name: Go Test Report
+        uses: dorny/test-reporter@v2
+        if: always()
+        with:
+          name: Go Test Report
+          path: go-test-results.xml
+          reporter: java-junit
 
       - name: Run frontend tests with coverage
         run: cd web && bun run test -- --coverage

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,7 +33,7 @@ jobs:
         run: gotestsum --junitfile go-test-results.xml -- -coverprofile=coverage.out ./...
 
       - name: Go Test Report
-        uses: dorny/test-reporter@v2
+        uses: dorny/test-reporter@v3
         if: always()
         with:
           name: Go Test Report


### PR DESCRIPTION
## Summary
- Install `gotestsum` to produce JUnit XML from Go tests
- Use `dorny/test-reporter@v2` to render results as a GitHub check ("Go Test Report")
- Matches the existing Vitest Test Report experience for the frontend

## Test plan
- [ ] Verify "Go Test Report" check appears on PRs with expandable test results

🤖 Generated with [Claude Code](https://claude.com/claude-code)